### PR TITLE
Fix/window closing bug

### DIFF
--- a/lua/let-it-snow/snow.lua
+++ b/lua/let-it-snow/snow.lua
@@ -201,7 +201,7 @@ end
 local function update_grid(buf, old_grid, lines)
     win = vim.api.nvim_get_current_win()
 	local height = vim.api.nvim_buf_line_count(buf)
-	local width, err = vim.api.nvim_win_get_width(win)
+	local width = vim.api.nvim_win_get_width(win)
 
 	local new_grid = make_grid(height, width)
 

--- a/lua/let-it-snow/snow.lua
+++ b/lua/let-it-snow/snow.lua
@@ -199,7 +199,7 @@ local function update_snowpile(row, col, old_grid, new_grid, lines)
 end
 
 local function update_grid(buf, old_grid, lines)
-    win = vim.api.nvim_get_current_win()
+    local win = vim.api.nvim_get_current_win()
 	local height = vim.api.nvim_buf_line_count(buf)
 	local width = vim.api.nvim_win_get_width(win)
 
@@ -241,7 +241,7 @@ local function get_lines(buf)
 	return lines
 end
 
-local function main_loop(win, buf, grid)
+local function main_loop(buf, grid)
 	local start = os.clock() * 1000
 	local lines = get_lines(buf)
 
@@ -254,7 +254,7 @@ local function main_loop(win, buf, grid)
 
 	if M.running[buf] then
 		vim.defer_fn(function()
-			main_loop(win, buf, grid)
+			main_loop(buf, grid)
 		end, wait_time)
 	else
 		clear_snow(buf)
@@ -282,7 +282,7 @@ M._let_it_snow = function()
 	M.running[buf] = true
 
 	vim.defer_fn(function()
-		main_loop(win, buf, initial_grid)
+		main_loop(buf, initial_grid)
 	end, 0)
 end
 

--- a/lua/let-it-snow/snow.lua
+++ b/lua/let-it-snow/snow.lua
@@ -200,7 +200,12 @@ end
 
 local function update_grid(win, buf, old_grid, lines)
 	local height = vim.api.nvim_buf_line_count(buf)
-	local width = vim.api.nvim_win_get_width(win)
+	local width, err = pcall(vim.api.nvim_win_get_width(win))
+
+    if err then
+        win = vim.api.nvim_get_current_win()
+        width = vim.api.nvim_win_get_width(win)
+    end
 
 	local new_grid = make_grid(height, width)
 

--- a/lua/let-it-snow/snow.lua
+++ b/lua/let-it-snow/snow.lua
@@ -198,14 +198,10 @@ local function update_snowpile(row, col, old_grid, new_grid, lines)
 	end
 end
 
-local function update_grid(win, buf, old_grid, lines)
+local function update_grid(buf, old_grid, lines)
+    win = vim.api.nvim_get_current_win()
 	local height = vim.api.nvim_buf_line_count(buf)
-	local width, err = pcall(vim.api.nvim_win_get_width(win))
-
-    if err then
-        win = vim.api.nvim_get_current_win()
-        width = vim.api.nvim_win_get_width(win)
-    end
+	local width, err = vim.api.nvim_win_get_width(win)
 
 	local new_grid = make_grid(height, width)
 
@@ -252,7 +248,7 @@ local function main_loop(win, buf, grid)
 	clear_snow(buf)
 	show_grid(buf, grid, lines)
 
-	grid = update_grid(win, buf, grid, lines)
+	grid = update_grid(buf, grid, lines)
 
 	local wait_time = math.max(0, settings.settings.delay - (os.clock() * 1000 - start))
 


### PR DESCRIPTION
This fixes an error that occurs when you close a window (opened with `<c-w>v`) using `:q`.

The error happens since the window reference is static in the main loop, but it can be fixed by removing the `win` argument to `update_grid` and `main_loop`, and instead always just get the current window.